### PR TITLE
Disruption index visualization

### DIFF
--- a/indices/algos.py
+++ b/indices/algos.py
@@ -40,6 +40,27 @@ def count_papers_citing(dois: set, graph: DiGraph) -> int:
             papers_citing.add(source)
     return len(papers_citing)
 
+
+def all_nodes_disruption_index(graph) -> dict:
+    """
+    Run the disruption_index function on all nodes
+
+    This function wraps `disruption_index` to make it behave the same way as networkx
+    graph centrality functions
+
+    Arguments
+    ---------
+    graph: The graph containing all citations
+
+    Returns
+    -------
+    node_to_metric: A dict mapping each graph node to its corresponding disruption index value
+    """
+    node_to_metric = {}
+    for node in graph.nodes:
+        node_to_metric[node] = disruption_index(node, graph)
+    return node_to_metric
+
 def disruption_index(doi: str, graph: DiGraph) ->  float:
     """
     Calculates the disruption index from Wu, Wang, and Evans.

--- a/indices/algos.py
+++ b/indices/algos.py
@@ -95,24 +95,35 @@ def disruption_index(doi: str, graph: DiGraph) ->  float:
     # Nodes citing both the node of interest and the articles it cites
     center_and_cited = 0
 
-    for _, out_node in graph.out_edges(doi):
-        out_dois.add(out_node)
+    out_dois = set(graph.successors(doi))
 
-    for in_node, _ in graph.in_edges(doi):
+    for in_node in graph.predecessors(doi):
         if cites_downstream(in_node, graph, out_dois):
             center_and_cited += 1
         else:
             center_only += 1
 
     downstream_citations = count_papers_citing(out_dois, graph)
+
+    # If we're missing data about what the paper cites, the metric probably isn't meaningful
+    if downstream_citations == 0:
+        return None
+
     # Don't count center paper
     downstream_citations -= 1
 
     di_denom = center_only + downstream_citations
     di_num = center_only - center_and_cited
 
-    # Return 0 for singleton nodes
+    # Return None for singleton nodes
     if di_denom == 0:
-        return 0
+        return None
+
+    try:
+        assert abs(di_num / di_denom) <= 1
+    except AssertionError as e:
+        print(downstream_citations)
+        print(doi)
+        raise AssertionError
 
     return di_num / di_denom

--- a/indices/run_metric_on_graph.py
+++ b/indices/run_metric_on_graph.py
@@ -24,6 +24,9 @@ if __name__ == '__main__':
     with open(args.graph_file, 'rb') as in_file:
         graph = pickle.load(in_file)
 
+    # Remove self-loops
+    graph.remove_edges_from(nx.selfloop_edges(graph))
+
     # Run metric on graph
     if args.metric == 'betweenness_centrality':
         node_to_metric = nx.betweenness_centrality(graph, k=100)

--- a/indices/run_metric_on_graph.py
+++ b/indices/run_metric_on_graph.py
@@ -6,6 +6,8 @@ import pickle
 
 import networkx as nx
 
+import algos
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('graph_file',
@@ -28,7 +30,7 @@ if __name__ == '__main__':
     elif args.metric == 'pagerank':
         node_to_metric = nx.pagerank(graph)
     elif args.metric == 'disruption_idx':
-        raise NotImplementedError
+        node_to_metric = algos.all_nodes_disruption_index(graph)
 
     # Build path to save the results to
     in_file_name = os.path.basename(args.graph_file)


### PR DESCRIPTION
This PR adds the infrastructure to calculate the disruption index for networkx graphs, and visualizes their results in a notebook.
Here are representative images of the results, since plotly still doesn't play well with large data or Github
![Screenshot from 2022-06-28 10-18-55](https://user-images.githubusercontent.com/15317110/176208326-0e3eb0b9-dd48-4879-87b3-3637f894603e.png)
![Screenshot from 2022-06-28 10-18-19](https://user-images.githubusercontent.com/15317110/176208336-4a5808b2-984d-4191-aa38-aa9716b9c725.png)
![Screenshot from 2022-06-28 10-18-02](https://user-images.githubusercontent.com/15317110/176208341-ef574201-ede5-44dc-800b-714f710dab58.png)

Changes:
- Add the `all_nodes_disruption_index` function to run the disruption index on all nodes in a graph
- Switch from `in_edges` and `out_edges` idiom to `successors` and `predecessors` idiom
- Fix a bug where missing citations would cause disruption indices of +- 2
- Add the disruption index to `run_metrics_on_graph.py`
